### PR TITLE
Fixed stats hover and y-axis label formatting 

### DIFF
--- a/src/template/graphContainer/GraphContainer.js
+++ b/src/template/graphContainer/GraphContainer.js
@@ -14,10 +14,12 @@ export function GraphContainer(props) {
   var removedPoints = points.splice(0, 3); // removed last 3 elements
   var removedLabels = labels.splice(0, 3); // removed last 3 elements
 
-  // function to format big numbers in 2K, 320K, etc.
+  // function to format big numbers in 2K, 320K, 1M etc.
   const kFormatter = (num) => {
-    return Math.abs(num) > 1000000
-      ? Math.sign(num) * (Math.abs(num) / 1000000).toFixed(1) + 'k'
+    return Math.abs(num) >= 1000000
+      ? Math.sign(num) * (Math.abs(num) / 1000000).toFixed(1) + 'm'
+      : Math.abs(num) >= 1000
+      ? Math.sign(num) * (Math.abs(num) / 1000).toFixed(1) + 'k'
       : Math.sign(num) * Math.abs(num);
   };
 
@@ -70,7 +72,6 @@ export function GraphContainer(props) {
                 // max: _.max(points) + plotPointGap,
                 stepSize: plotPointGap,
                 padding: 10,
-
                 callback: function (label, index, labels) {
                   switch (label) {
                     default:

--- a/src/template/graphContainer/GraphContainer.js
+++ b/src/template/graphContainer/GraphContainer.js
@@ -17,10 +17,12 @@ export function GraphContainer(props) {
   // function to format big numbers in 2K, 320K, 1M etc.
   const kFormatter = (num) => {
     return Math.abs(num) >= 1000000
-      ? Math.sign(num) * (Math.abs(num) / 1000000).toFixed(1) + 'm'
+      ? Math.sign(num) * (Math.abs(num) / 1000000).toFixed(2) + 'm'
       : Math.abs(num) >= 1000
-      ? Math.sign(num) * (Math.abs(num) / 1000).toFixed(1) + 'k'
-      : Math.sign(num) * Math.abs(num);
+      ? Math.sign(num) * (Math.abs(num) / 1000).toFixed(2) + 'k'
+      : Math.abs(num) > 1
+      ? Math.sign(num) * Math.abs(num).toFixed(2)
+      : Math.sign(num) * Math.abs(num).toFixed(3);
   };
 
   const drawCharts = React.useCallback(() => {
@@ -53,6 +55,11 @@ export function GraphContainer(props) {
         },
         tooltips: {
           enabled: true,
+          callbacks: {
+            label: function (tooltipItem, data) {
+              return kFormatter(tooltipItem.yLabel);
+            },
+          },
         },
         maintainAspectRatio: false,
 


### PR DESCRIPTION
Formatting is now the following:

For numbers below 1, 3 decimals.
[1-999] - 2 decimals.
[1000-999999] - 2 decimals with a 'k', for ex. 98.23k, 203.25k.
1000000+ - 2 decimals with a 'm', for ex. 1.05m, 23.51m.

